### PR TITLE
fix some issues, allow using all lessons from HaxePloverLearn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ ploverlearn:
 	cp resources/* build
 	rm build/template.html
 	python src/translate-lessons.py
+
+clean:
+	rm -r build

--- a/resources/ploverlearn.js
+++ b/resources/ploverlearn.js
@@ -1,6 +1,6 @@
 var PloverLearnQuiz = function(fields) {
 	this.fields = fields;
-	this.index = 0;
+	this.index = -1;
 };
 
 PloverLearnQuiz.prototype.title = function() {
@@ -58,7 +58,7 @@ PloverLearnQuiz.prototype.isLastQuestion = function() {
 
 PloverLearnQuiz.prototype.moveToNextQuestion = function() {
 	if (this.isLastQuestion()) {
-		this.index = 0;
+		this.index = -1;
 	} else {
 		this.index++;
 	}

--- a/src/translate-lessons.py
+++ b/src/translate-lessons.py
@@ -16,12 +16,12 @@ def parse_lesson_file(filename):
 
 	questions = []
 	for line in lines[2:]:
-		if line.startswith("'"):
-			(word, hint) = line.split(':')
-			word = word.replace("'",'').strip()
+		if line.startswith("'") and line.find("': ") > 1:
+			(word, hint) = line.split("': ")
+			word = word.replace("'", '', 1).strip()
 			hint = hint.strip()
 			questions.append([word,hint])
-		else:
+		elif line.find('=') > -1:
 			(name, value) = line.split('=')
 			fields[name] = value
 
@@ -74,9 +74,5 @@ def main():
 			if x=='lesson.txt'],
 			None)
 
-	handle_lesson_file('lessons/Lesson10/lesson.txt',
-		template=template)
-
 if __name__=='__main__':
 	main()
-


### PR DESCRIPTION
I did try to use the newest lessons from
https://github.com/dimonster/HaxePloverLearn by changing
`os.path.walk('lessons'` to `os.path.walk('../HaxePloverLearn/lessons'`
but this did not work for all lessons. This commits do fix these issues:
- allow colon in word by splitting at `':` instead of `:`
- allow `'` in word, don't replace all `'`, only the first (the last one is
  included in the split and therefore not part of the word) -- this was a
  bug even with the included lessons, see lesson 4a
- check for line containing `=` before splitting it at `=`
- don't add lessons/Lesson10/lesson.txt manually (done already by walking
  the path

Additionally, there was a bug, that the first word of each lesson was not used. The reason
was that index was initialized with 0, but before showing the first word,
`moveToNextQuestion` is called, incrementing index and therefore always
starting with index 1. By initializing index to -1, this bug is fixed.
